### PR TITLE
Add vits14_reg4 config

### DIFF
--- a/dinov2/configs/train/vits14_reg4.yaml
+++ b/dinov2/configs/train/vits14_reg4.yaml
@@ -1,0 +1,51 @@
+dino:
+  head_n_prototypes: 131072
+  head_bottleneck_dim: 384
+  do_kde: True
+  kde_loss_weight: .05
+  koleo_loss_weight: 0
+  do_koleo: False
+ibot:
+  loss_weight: 1.0
+  mask_sample_probability: 0.5
+  mask_ratio_min_max:
+    - 0.1
+    - 0.45
+  separate_head: true
+  head_n_prototypes: 131072
+train:
+  sample_list_path: /block/TCGA/sample_dataset_30.txt # gives paths to svs files for data loading if streaming_from_hf=False
+  streaming_from_hf: false # if True, dataset is streamed from HuggingFace Hub, and sample_list_path is ignored. You should lower num_workers to 4
+  streaming_dataset_path: medarc/TCGA-12K-parquet
+  batch_size_per_gpu: 48
+  centering: sinkhorn_knopp
+  use_pretrained: True
+  OFFICIAL_EPOCH_LENGTH: 1250
+  num_workers: 24 # set to 4 if streaming_from_hf=True
+  prefetch_factor: 8
+  skip_checkpointer: true # set True if you don't need to resume training (this yields training speedup and less space usage)
+student:
+  arch: vit_small
+  patch_size: 14
+  drop_path_rate: 0.1 # drop path rate for vit_small
+  ffn_layer: swiglufused
+  block_chunks: 4
+  num_register_tokens: 4
+  interpolate_antialias: true # positional embeddings are interpolated with antialiasing
+  interpolate_offset: 0.0
+teacher:
+  momentum_teacher: 0.994
+optim:
+  epochs: 110 # epochs and early_stop for 137.5k pretraining steps
+  early_stop: 110
+  weight_decay_end: 0.2
+  base_lr: 7.0e-04 # learning rate for vit_small
+  warmup_epochs: 10
+  layerwise_decay: 1.0
+crops:
+  local_crops_size: 98
+evaluation:
+  eval_period_iterations: 2500 # save checkpoints frequently for evaluation
+  bach_root: /block/eva-data/bach
+  breakhis_root: /block/eva-data/breakhis
+  pcam_root: /block/eva-data/patch_camelyon


### PR DESCRIPTION
Added new vits14_reg4.yaml config for ViT-small training

Key changes: 
arch=vit_small, 
drop_path_rate=0.1, 
base_lr=7e-4, 
interpolate_antialias=true, 
interpolate_offset=0.0, 
epochs, early_stop = 110, 
eval_period-iterations = 2500, 
eval dataset paths updated.