### PR TITLE
Cache OpenSlide handles for offline SVS loading

### DIFF
--- a/dinov2/data/datasets/slide_dataset.py
+++ b/dinov2/data/datasets/slide_dataset.py
@@ -2,12 +2,42 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
+import atexit
+from collections import OrderedDict
 from typing import Any, Tuple
+
 from .extended import ExtendedVisionDataset
 from pathlib import Path
 from openslide import OpenSlide
 import numpy as np
 import cv2
+
+_SLIDE_CACHE: "OrderedDict[str, OpenSlide]" = OrderedDict()
+_SLIDE_CACHE_LIMIT = 4096
+
+
+def _get_slide(path: str) -> OpenSlide:
+    """Return a cached OpenSlide handle, opening and LRU-evicting as needed."""
+    slide = _SLIDE_CACHE.get(path)
+    if slide is not None:
+        _SLIDE_CACHE.move_to_end(path)
+        return slide
+    slide = OpenSlide(path)
+    _SLIDE_CACHE[path] = slide
+    if len(_SLIDE_CACHE) > _SLIDE_CACHE_LIMIT:
+        _, old = _SLIDE_CACHE.popitem(last=False)
+        old.close()
+    return slide
+
+
+def _close_all_slides():
+    for slide in _SLIDE_CACHE.values():
+        slide.close()
+    _SLIDE_CACHE.clear()
+
+
+atexit.register(_close_all_slides)
+
 
 class SlideDataset(ExtendedVisionDataset):
     def __init__(self, root, sample_list_path, *args, **kwargs) -> None:
@@ -24,7 +54,7 @@ class SlideDataset(ExtendedVisionDataset):
     def get_all(self, index):
         parts = self.image_files[index].split(" ")
         path = parts[0]
-        image = OpenSlide(path)
+        image = _get_slide(path)
         return image, path
 
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
@@ -35,16 +65,13 @@ class SlideDataset(ExtendedVisionDataset):
         y = int(y)
         level = int(level)
 
-        image = OpenSlide(path)
+        image = _get_slide(path)
 
         patch_size = 224
-        height = image.level_dimensions[0][1]
-        width = image.level_dimensions[0][0]
 
-        #read_region is based on the top left pixel in the level 0, not our current level
         patch = image.read_region((x, y), level=level, size=(patch_size, patch_size))
 
-        res = patch.convert("RGB") # Removes alpha - not sure this is the best way to do this thuogh
+        res = patch.convert("RGB")
         if self.transforms is not None:
             return self.transforms(res, None), index
 

--- a/dinov2/data/datasets/slide_dataset.py
+++ b/dinov2/data/datasets/slide_dataset.py
@@ -16,19 +16,6 @@ _SLIDE_CACHE: "OrderedDict[str, OpenSlide]" = OrderedDict()
 _SLIDE_CACHE_LIMIT = 512
 
 
-def _get_slide(path: str) -> OpenSlide:
-    slide = _SLIDE_CACHE.get(path)
-    if slide is not None:
-        _SLIDE_CACHE.move_to_end(path)
-        return slide
-    slide = OpenSlide(path)
-    _SLIDE_CACHE[path] = slide
-    if len(_SLIDE_CACHE) > _SLIDE_CACHE_LIMIT:
-        _, old = _SLIDE_CACHE.popitem(last=False)
-        old.close()
-    return slide
-
-
 def _close_all_slides():
     for slide in _SLIDE_CACHE.values():
         slide.close()
@@ -53,7 +40,15 @@ class SlideDataset(ExtendedVisionDataset):
     def get_all(self, index):
         parts = self.image_files[index].split(" ")
         path = parts[0]
-        image = _get_slide(path)
+        image = _SLIDE_CACHE.get(path)
+        if image is None:
+            image = OpenSlide(path)
+            _SLIDE_CACHE[path] = image
+            if len(_SLIDE_CACHE) > _SLIDE_CACHE_LIMIT:
+                _, old = _SLIDE_CACHE.popitem(last=False)
+                old.close()
+        else:
+            _SLIDE_CACHE.move_to_end(path)
         return image, path
 
     def __getitem__(self, index: int) -> Tuple[Any, Any]:
@@ -64,7 +59,15 @@ class SlideDataset(ExtendedVisionDataset):
         y = int(y)
         level = int(level)
 
-        image = _get_slide(path)
+        image = _SLIDE_CACHE.get(path)
+        if image is None:
+            image = OpenSlide(path)
+            _SLIDE_CACHE[path] = image
+            if len(_SLIDE_CACHE) > _SLIDE_CACHE_LIMIT:
+                _, old = _SLIDE_CACHE.popitem(last=False)
+                old.close()
+        else:
+            _SLIDE_CACHE.move_to_end(path)
 
         patch_size = 224
 

--- a/dinov2/data/datasets/slide_dataset.py
+++ b/dinov2/data/datasets/slide_dataset.py
@@ -13,11 +13,10 @@ import numpy as np
 import cv2
 
 _SLIDE_CACHE: "OrderedDict[str, OpenSlide]" = OrderedDict()
-_SLIDE_CACHE_LIMIT = 4096
+_SLIDE_CACHE_LIMIT = 128
 
 
 def _get_slide(path: str) -> OpenSlide:
-    """Return a cached OpenSlide handle, opening and LRU-evicting as needed."""
     slide = _SLIDE_CACHE.get(path)
     if slide is not None:
         _SLIDE_CACHE.move_to_end(path)

--- a/dinov2/data/datasets/slide_dataset.py
+++ b/dinov2/data/datasets/slide_dataset.py
@@ -13,7 +13,7 @@ import numpy as np
 import cv2
 
 _SLIDE_CACHE: "OrderedDict[str, OpenSlide]" = OrderedDict()
-_SLIDE_CACHE_LIMIT = 128
+_SLIDE_CACHE_LIMIT = 512
 
 
 def _get_slide(path: str) -> OpenSlide:

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -1136,6 +1136,8 @@ def do_train(cfg, model, resume=False):
             sampler_advance=0,  # TODO(qas): fix this -- start_iter * cfg.train.batch_size_per_gpu,
             drop_last=True,
             collate_fn=collate_fn,
+            persistent_workers=cfg.train.num_workers > 0,
+            prefetch_factor=getattr(cfg.train, "prefetch_factor", 2),
         )
 
     # training loop

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -1137,7 +1137,7 @@ def do_train(cfg, model, resume=False):
             drop_last=True,
             collate_fn=collate_fn,
             persistent_workers=cfg.train.num_workers > 0,
-            prefetch_factor=getattr(cfg.train, "prefetch_factor", 2),
+            prefetch_factor=cfg.train.prefetch_factor,
         )
 
     # training loop


### PR DESCRIPTION
This PR improves the offline SVS training path by reusing `OpenSlide` objects in `SlideDataset` and by forwarding the configured DataLoader worker settings for non-streaming training.

## Current changes

- `SlideDataset` now uses a module-level LRU cache for `OpenSlide` objects in both `get_all` and `__getitem__`.
- The cache is capped at `_SLIDE_CACHE_LIMIT = 512` per worker process. Evicted slides are closed immediately, and an `atexit` hook closes anything still cached when the worker exits.
- The cache lookup is inlined at the call sites to match the repo preference in `AGENTS.md` against small helper functions.
- The offline SVS DataLoader now passes `persistent_workers=cfg.train.num_workers > 0`.
- The offline SVS DataLoader now passes `prefetch_factor=cfg.train.prefetch_factor`, so this remains YAML-configured and fail-loud instead of using a fallback default.

## Why this is useful

The old `SlideDataset.__getitem__` opened `OpenSlide(path)` for every sampled patch. Python OpenSlide closes objects when they are deleted, so the previous wording about leaking thousands of file descriptors was too strong. The practical issue is repeated OpenSlide object creation and close churn across millions of sampled patches, with no reuse when the sampler returns to a recently used slide.

The new code keeps reuse bounded and explicit: cache hits reuse an existing slide handle, misses open a slide, and LRU eviction closes the oldest cached slide. This should help small 1-GPU runs where data loading is visible, while keeping memory growth controlled for larger multi-GPU H100 runs with many DataLoader workers.

## Validation

Original author benchmark on H100, ViT-S/14, 1 GPU, 5k-sample subset with 1,314 unique SVS slides:

- Production-like worker count: about 7% iter_time improvement, 0.275s to 0.255s per step.
- 2 workers, where data loading was the bottleneck: 28% data_time reduction, 1.10s to 0.79s, with the original 4096-entry cache.

Additional review validation on `n-1` used actual shuffled SVS patch reads from `/block/TCGA/sample_dataset_30.txt`:

- `sample_dataset_30.txt`: 24,985,184 patch rows, 11,368 unique slides.
- Benchmark: 3,000 shuffled `read_region(...).convert("RGB")` reads from a 200k-row sample.

| Cache cap | Time | Samples/s | Hit rate | Process RSS |
|---:|---:|---:|---:|---:|
| 128 | 43.36s | 69.19 | 1.0% | ~0.99 GB |
| 512 | 43.51s | 68.94 | 3.5% | ~1.66 GB |
| 900 | 42.77s | 70.15 | 6.1% | ~2.35 GB |
| 4096 | 42.95s | 69.86 | 11.3% | ~5.31 GB |

The current 512 cap is a compromise from that validation: 4096 retained many more slide objects and used much more memory in a single process without improving this random-read throughput, while 128 had almost no reuse under shuffled sampling.

## Files changed

- `dinov2/data/datasets/slide_dataset.py`: bounded OpenSlide LRU cache, explicit close on eviction, atexit cleanup.
- `dinov2/train/train.py`: persistent workers and YAML-backed prefetch factor for the offline SVS path.
