### PR TITLE
feat: probabilistic HSV tissue sampling (fixes #13)

### DIFF
--- a/dinov2/data/datasets/slide_dataset.py
+++ b/dinov2/data/datasets/slide_dataset.py
@@ -2,12 +2,13 @@
 # This source code is licensed under the Apache License, Version 2.0
 # found in the LICENSE file in the root directory of this source tree.
 
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 from .extended import ExtendedVisionDataset
 from pathlib import Path
 from openslide import OpenSlide
 import numpy as np
 import cv2
+import random
 
 class SlideDataset(ExtendedVisionDataset):
     def __init__(self, root, sample_list_path, *args, **kwargs) -> None:
@@ -50,20 +51,40 @@ class SlideDataset(ExtendedVisionDataset):
 
         return res, None, index
         
-    def hsv(self, tile_rgb, patch_size):
+    def hsv(self, tile_rgb, patch_size) -> Optional[Any]:
+        """Filter patches using probabilistic HSV-based tissue detection.
+
+        Instead of a hard accept/reject threshold, patches with a tissue ratio
+        between ``low_ratio`` and ``high_ratio`` are accepted with probability
+        equal to their ratio.  This biases the dataset toward informative
+        patches while still allowing occasional lighter/borderline tiles
+        through, rather than discarding them entirely.
+
+        Acceptance rules:
+          ratio >= high_ratio  → always accept  (p = 1.0)
+          low_ratio <= ratio < high_ratio → accept with p = ratio
+          ratio < low_ratio    → always reject  (p = 0.0)
+        """
+        low_ratio = 0.10
+        high_ratio = 0.60
+
         tile = np.array(tile_rgb)
         tile = cv2.cvtColor(tile, cv2.COLOR_RGB2HSV)
-        min_ratio = .6
-        
+
         lower_bound = np.array([90, 8, 103])
         upper_bound = np.array([180, 255, 255])
 
         mask = cv2.inRange(tile, lower_bound, upper_bound)
-
         ratio = np.count_nonzero(mask) / mask.size
-        if ratio > min_ratio:
+
+        if ratio >= high_ratio:
             return tile_rgb
-        else: # ratio failed, reject
+        elif ratio >= low_ratio:
+            # Probabilistic acceptance: p = ratio
+            if random.random() < ratio:
+                return tile_rgb
+            return None
+        else:
             return None
 
     def __len__(self) -> int:


### PR DESCRIPTION
## Summary

Closes #13.

The current `SlideDataset.hsv()` method uses a hard accept/reject threshold (`ratio >= 0.6`): any patch with fewer than 60 % "tissue" pixels is silently discarded.  As the issue notes, this completely throws away borderline and lighter patches that could still carry useful information.

This PR replaces the binary filter with a **three-zone probabilistic scheme**:

| Tissue ratio `r`           | Acceptance rule             |
|----------------------------|-----------------------------|
| `r >= 0.60`                | Always accept (p = 1.0)     |
| `0.10 <= r < 0.60`         | Accept with **p = r**       |
| `r < 0.10`                 | Always reject (p = 0.0)     |

Patches with a ratio of e.g. 0.35 are now kept ~35 % of the time instead of never.  This biases the dataset toward high-tissue patches while still allowing borderline tiles through with a probability proportional to their tissue content.

## Changes

* `dinov2/data/datasets/slide_dataset.py`
  - `Optional` added to imports; `random` imported.
  - `hsv()` docstring and implementation updated.  The hard `min_ratio = 0.6` is replaced by `low_ratio = 0.10` / `high_ratio = 0.60` with the probabilistic middle band.

## Test plan

- [ ] Verify `hsv()` with synthetic numpy arrays at ratio 0.05, 0.35, 0.65.
- [ ] Smoke-test a short training run (`run_ablation.sh`) to confirm the data loader still streams correctly without NaN patches.
- [ ] Optionally: histogram the accepted-patch ratio distribution before vs after to confirm the expected shift.

Made with [Cursor](https://cursor.com)