### PR TITLE
feat: μP (maximal update parametrization) for automatic LR scaling (closes #41)

### DIFF
--- a/dinov2/configs/ssl_default_config.yaml
+++ b/dinov2/configs/ssl_default_config.yaml
@@ -106,6 +106,7 @@ optim:
   layerwise_decay: 0.9
   adamw_beta1: 0.9
   adamw_beta2: 0.999
+  use_mup: false  # set true to enable μP LR scaling (github.com/microsoft/mup)
 crops:
   global_crops_scale:
   - 0.32

--- a/dinov2/models/mup_utils.py
+++ b/dinov2/models/mup_utils.py
@@ -1,0 +1,118 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# This source code is licensed under the Apache License, Version 2.0
+# found in the LICENSE file in the root directory of this source tree.
+"""μP (maximal update parametrization) — thin wrappers over the `mup` library.
+
+Basic usage (matches the mup README exactly):
+
+    # 1. Build tiny reference backbones (never trained)
+    base  = _build_ref_backbone(cfg, embed_dim=64,  num_heads=1)
+    delta = _build_ref_backbone(cfg, embed_dim=128, num_heads=2)
+
+    # 2. Persist shapes to disk (needed for checkpoint resume)
+    make_base_shapes(base, delta, shapes_path)
+
+    # 3. Apply μP to the actual backbone — rescales init and attaches
+    #    p.infshape to every parameter.  Call BEFORE FSDP wrapping.
+    #    Because the FSDP wrapper uses use_orig_params=True, the original
+    #    parameter objects (and their infshape attributes) are preserved
+    #    after wrapping, so MuAdamW can read them at optimizer construction.
+    set_base_shapes(backbone, shapes_path)
+
+    # 4. Build optimizer with MuAdamW (instead of plain AdamW)
+    optimizer = MuAdamW(param_groups, lr=..., betas=...)
+
+See: https://github.com/microsoft/mup
+     Paper: https://arxiv.org/abs/2203.03466
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import torch.nn as nn
+
+logger = logging.getLogger("dinov2")
+
+BASE_SHAPES_FILENAME = "mup_base_shapes.bsh"
+
+
+def _depth_for_arch(arch: str) -> int:
+    if "giant" in arch:
+        return 40
+    if "large" in arch:
+        return 24
+    if "base" in arch:
+        return 12
+    return 12  # small / default
+
+
+def _build_ref_backbone(cfg, embed_dim: int, num_heads: int) -> nn.Module:
+    """Build a minimal ViT backbone used only for shape registration.
+
+    These models are never trained; we only extract parameter shape
+    information from them (base and delta), following the mup README.
+    """
+    from dinov2.models.vision_transformer import DinoVisionTransformer
+
+    return DinoVisionTransformer(
+        img_size=224,
+        patch_size=cfg.student.patch_size,
+        embed_dim=embed_dim,
+        depth=_depth_for_arch(cfg.student.arch),
+        num_heads=num_heads,
+        init_values=cfg.student.layerscale,
+        ffn_layer=cfg.student.ffn_layer,
+        block_chunks=0,       # no chunking for tiny reference models
+        qkv_bias=cfg.student.qkv_bias,
+        proj_bias=cfg.student.proj_bias,
+        ffn_bias=cfg.student.ffn_bias,
+        num_register_tokens=cfg.student.num_register_tokens,
+        interpolate_offset=cfg.student.interpolate_offset,
+        interpolate_antialias=cfg.student.interpolate_antialias,
+    )
+
+
+def setup_mup(backbone: nn.Module, cfg, output_dir: str) -> str:
+    """Apply μP to *backbone* in-place and save base shapes for later reuse.
+
+    Must be called **before** FSDP wrapping and **before** loading pretrained
+    weights.  The FSDP wrapper already uses ``use_orig_params=True``, which
+    preserves the original parameter objects (and their ``infshape``
+    attributes) after wrapping, so ``MuAdamW`` can read them when the
+    optimizer is built.
+
+    Args:
+        backbone: The student backbone (``model.student.backbone``).
+        cfg: Training config (used to mirror the backbone architecture).
+        output_dir: Directory where the ``.bsh`` shapes file is written.
+
+    Returns:
+        Path to the saved shapes file.
+    """
+    try:
+        from mup import make_base_shapes, set_base_shapes
+    except ImportError as exc:
+        raise ImportError(
+            "The 'mup' package is required for μP training. "
+            "Add 'mup>=1.0.0' to pyproject.toml and reinstall."
+        ) from exc
+
+    # head_dim = 64 throughout the ViT family; keep it fixed so only
+    # embed_dim varies between base and delta, matching the scaling axis.
+    base  = _build_ref_backbone(cfg, embed_dim=64,  num_heads=1)
+    delta = _build_ref_backbone(cfg, embed_dim=128, num_heads=2)
+
+    os.makedirs(output_dir, exist_ok=True)
+    shapes_path = os.path.join(output_dir, BASE_SHAPES_FILENAME)
+
+    logger.info("μP: saving base shapes to %s", shapes_path)
+    make_base_shapes(base, delta, shapes_path)
+    del base, delta  # free memory immediately; we only needed the shapes
+
+    logger.info("μP: calling set_base_shapes on backbone")
+    set_base_shapes(backbone, shapes_path)
+    # set_base_shapes rescales the freshly-initialized parameters to match μP
+    # and attaches a `p.infshape` attribute to every parameter tensor.
+
+    return shapes_path

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -127,6 +127,23 @@ For python-based LazyConfig, use "path.key=value".
 
 
 def build_optimizer(cfg, params_groups):
+    if cfg.optim.get("use_mup", False):
+        # Use MuAdamW from the mup library so that each parameter's LR is
+        # automatically divided by its infshape.width_mult().
+        # MuAdamW splits every param into its own group and scales lr;
+        # we capture that scale as `mup_lr_scale` so apply_optim_scheduler
+        # can multiply it back in each step without overwriting the width scaling.
+        from mup import MuAdamW
+        optimizer = MuAdamW(
+            params_groups,
+            lr=1.0,  # placeholder; apply_optim_scheduler sets the real value
+            betas=(cfg.optim.adamw_beta1, cfg.optim.adamw_beta2),
+        )
+        # MuAdamW sets pg["lr"] = 1.0 / width_mult() for each refined group.
+        # Store it so apply_optim_scheduler can multiply by it each step.
+        for pg in optimizer.param_groups:
+            pg["mup_lr_scale"] = pg["lr"]
+        return optimizer
     return torch.optim.AdamW(params_groups, betas=(cfg.optim.adamw_beta1, cfg.optim.adamw_beta2))
 
 
@@ -183,8 +200,13 @@ def apply_optim_scheduler(optimizer, lr, wd, last_layer_lr):
         is_last_layer = param_group["is_last_layer"]
         lr_multiplier = param_group["lr_multiplier"]
         wd_multiplier = param_group["wd_multiplier"]
+        # mup_lr_scale is set by build_optimizer when use_mup=True.
+        # It stores the per-parameter width-based LR factor that MuAdamW
+        # computed at init time (1/width_mult()), so we can multiply it in
+        # here instead of setting lr absolutely and losing the μP scaling.
+        mup_lr_scale = param_group.get("mup_lr_scale", 1.0)
         param_group["weight_decay"] = wd * wd_multiplier
-        param_group["lr"] = (last_layer_lr if is_last_layer else lr) * lr_multiplier
+        param_group["lr"] = (last_layer_lr if is_last_layer else lr) * lr_multiplier * mup_lr_scale
 
 _FULL_STATE_DICT_CFG = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
 
@@ -1262,6 +1284,18 @@ def main(args):
     cfg = setup(args)
     print(cfg)
     model = SSLMetaArch(cfg).to(torch.device("cuda"))
+
+    # Apply μP BEFORE loading pretrained weights and BEFORE FSDP wrapping.
+    # set_base_shapes rescales the freshly-initialized parameters and attaches
+    # p.infshape to every parameter.  Because the FSDP wrapper uses
+    # use_orig_params=True the original parameter objects (and their infshape
+    # attributes) are preserved after wrapping, so MuAdamW can read them when
+    # the optimizer is built in do_train().
+    if cfg.optim.get("use_mup", False):
+        from dinov2.models.mup_utils import setup_mup
+        logger.info("μP enabled — applying set_base_shapes to student backbone")
+        setup_mup(model.student.backbone, cfg, args.output_dir)
+
     #Load model here from pretrained.
     if cfg.train.use_pretrained:
         _load_pretrained_backbone(cfg, model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "timm>=1.0.9",
     # for HEST benchmarking:
     "hestcore==1.0.4",
+ # μP: automatic learning-rate scaling across model widths (issue #41)
+ "mup>=1.0.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

Closes #41.

Integrates Microsoft's [`mup` library](https://github.com/microsoft/mup) following the README recipe exactly:

\`\`\`python
from mup import make_base_shapes, set_base_shapes, MuAdamW

# 1. Build tiny reference backbones (never trained — shapes only)
base  = ViT(embed_dim=64,  num_heads=1)   # head_dim=64, fixed throughout
delta = ViT(embed_dim=128, num_heads=2)

# 2. Save shapes to disk for checkpoint resume
make_base_shapes(base, delta, "mup_base_shapes.bsh")

# 3. Apply μP to the actual model — rescales init + attaches p.infshape
set_base_shapes(backbone, "mup_base_shapes.bsh")

# 4. Use MuAdamW instead of AdamW
optimizer = MuAdamW(param_groups, lr=..., betas=...)
\`\`\`

### Why this works with FSDP

The existing FSDP wrapper already uses **`use_orig_params=True`** (see `dinov2/fsdp/__init__.py`). This preserves the original parameter objects — and their `p.infshape` attributes — after wrapping. So `MuAdamW` can read them when the optimizer is built.

### Call order in `main()`

| Step | What happens |
|------|-------------|
| 1 | Model created with random init |
| 2 | **`setup_mup(backbone)`** — `set_base_shapes` rescales init + attaches `infshape` |
| 3 | `_load_pretrained_backbone` — overwrites weights; `infshape` survives |
| 4 | `prepare_for_distributed_training` — FSDP wraps; `infshape` survives (`use_orig_params=True`) |
| 5 | `do_train` → `MuAdamW` reads `infshape`, scales `lr` per-param by `1/width_mult()` |

### `apply_optim_scheduler` fix

`MuAdamW` sets `pg["lr"] = global_lr / width_mult()` at init time. The existing `apply_optim_scheduler` was overwriting `lr` absolutely each step, which would erase the μP scaling. Fix: store `pg["mup_lr_scale"]` once at optimizer construction, then multiply it in at every scheduler step:

```python
pg["lr"] = (base_lr * lr_multiplier) * pg["mup_lr_scale"]
```

## Changes

| File | Change |
|------|--------|
| `dinov2/models/mup_utils.py` (new) | `setup_mup()`: builds base/delta, calls `make_base_shapes` + `set_base_shapes` |
| `dinov2/train/train.py` | `main()` calls `setup_mup`; `build_optimizer()` uses `MuAdamW` + stores `mup_lr_scale`; `apply_optim_scheduler()` multiplies by `mup_lr_scale` |
| `dinov2/configs/ssl_default_config.yaml` | Adds `optim.use_mup: false` |
| `pyproject.toml` | Adds `mup>=1.0.0` |

`param_groups.py` and `ssl_meta_arch.py` are **unchanged** from upstream.

## Usage

```yaml
# in your YAML config:
optim:
  use_mup: true
  base_lr: 2.0e-3   # tune on ViT-S; transfers to ViT-G automatically
```

## Test plan

- [ ] Run with `use_mup: false` (default) — verify training is identical to baseline.
- [ ] Run `run_ablation.sh` with `use_mup: true` — check that `mup_base_shapes.bsh` is created and param groups log `mup_lr_scale < 1.0` for backbone weight matrices.
- [ ] Verify μP coord check (`mup.coord_check`) on a small model confirms stable activations across widths.
- [ ] (Future) Demonstrate LR transfer: tune `base_lr` on ViT-S with `use_mup: true`; confirm same LR trains ViT-G stably.